### PR TITLE
Fix README.md examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Using `CUSUM` detection algorithm on simulated data set.
 
 ```python
 # import packages
+import numpy as np
+
 from kats.consts import TimeSeriesData
 from kats.detectors.cusum_detection import CUSUMDetector
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,17 @@ Here are a few sample snippets from a subset of Kats offerings:
 Using `Prophet` model to forecast the `air_passengers` data set.
 
 ```python
+import pandas as pd
+
 from kats.consts import TimeSeriesData
 from kats.models.prophet import ProphetModel, ProphetParams
 
 # take `air_passengers` data as an example
-air_passengers_df = pd.read_csv("../kats/data/air_passengers.csv")
+air_passengers_df = pd.read_csv(
+    "../kats/data/air_passengers.csv",
+    header=0,
+    names=["time", "passengers"],
+)
 
 # convert to TimeSeriesData object
 air_passengers_ts = TimeSeriesData(air_passengers_df)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,11 @@ We can extract meaningful features from the given time series data
 from kats.tsfeatures.tsfeatures import TsFeatures
 
 # take `air_passengers` data as an example
-air_passengers_df = pd.read_csv("../kats/data/air_passengers.csv")
+air_passengers_df = pd.read_csv(
+    "../kats/data/air_passengers.csv",
+    header=0,
+    names=["time", "passengers"],
+)
 
 # convert to TimeSeriesData object
 air_passengers_ts = TimeSeriesData(air_passengers_df)


### PR DESCRIPTION
## PR Summary

This small PR will fix the examples in the README.md. It is missing the imports for pandas and numpy. Also loading the air passenger data set from file is done without renaming the columns (time and passengers), thus throwing an error when transforming using `TimeSeriesData`.

My implementation will change the headers on load. Alternatively it can be renamed inplace  _after_ loading the csv as a dataframe using:
```python
air_passengers_df.rename(columns={"ds": "time", "y": "passengers"}, inplace=True)
```

I run black locally to make sure the file lints. Tests and other changes to the documentation do not apply. I removed the points from the checklist below.


## Kats

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/facebookresearch/Kats/blob/master/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

- [X] Fork the repo and create your branch from master.
- [X] Make sure your code lints.
- [x] If you haven't already, complete the Contributor License Agreement ("CLA").

Contributor License Agreement ("CLA")
In order to accept your pull request, we need you to submit a CLA. You only need to do this once to work on any of Facebook's open source projects.

Complete your CLA here: https://code.facebook.com/cla

`Ver: Kats v1.02`
