### PR TITLE
clean dates generation in VARModel_predict

### DIFF
--- a/kats/models/var.py
+++ b/kats/models/var.py
@@ -154,8 +154,8 @@ class VARModel(m.Model):
 
         last_date = self.data.time.max()
         dates = pd.date_range(start=last_date, periods=steps + 1, freq=self.freq)
-        # pyre-fixme[16]: `VARModel` has no attribute `dates`.
-        self.dates = dates[dates != last_date]  # Return correct number of periods
+        dates = dates[1:]  # Return correct number of periods
+        self.dates = dates
 
         # pyre-fixme[16]: `VARModel` has no attribute `fcst_dict`.
         self.fcst_dict = {}


### PR DESCRIPTION
Clean `self.dates` definition in `VARModel().predict`.
Test case `test_var_model.py` runs fine.