### PR TITLE
Add .to_numpy() to Detector plot methods

### DIFF
--- a/kats/detectors/bocpd.py
+++ b/kats/detectors/bocpd.py
@@ -433,7 +433,7 @@ class BOCPDetector(Detector):
         for ts_name in ts_names:
             ts_changepoints = change_points_per_ts[ts_name]
 
-            plt.plot(data_df[time_col_name].values, data_df[ts_name].values)
+            plt.plot(data_df[time_col_name].to_numpy(), data_df[ts_name].to_numpy())
 
             logging.info(
                 f"Plotting {len(ts_changepoints)} change points for {ts_name}."

--- a/kats/detectors/cusum_detection.py
+++ b/kats/detectors/cusum_detection.py
@@ -552,7 +552,7 @@ class CUSUMDetector(Detector):
 
         data_df = self.data.to_dataframe()
 
-        plt.plot(data_df[time_col_name], data_df[val_col_name])
+        plt.plot(data_df[time_col_name].to_numpy(), data_df[val_col_name].to_numpy())
 
         if len(change_points) == 0:
             logging.warning("No change points detected!")

--- a/kats/detectors/robust_stat_detection.py
+++ b/kats/detectors/robust_stat_detection.py
@@ -96,7 +96,7 @@ class RobustStatDetector(Detector):
 
         data_df = self.data.to_dataframe()
 
-        plt.plot(data_df[time_col_name], data_df[val_col_name])
+        plt.plot(data_df[time_col_name].to_numpy(), data_df[val_col_name].to_numpy())
 
         if len(change_points) == 0:
             logging.warning("No change points detected!")


### PR DESCRIPTION
Summary:
CUSUMDetector and RobustStatDetector are currently trying to plot pandas columns directly which is leading to the below error.

Here we add .to_numpy() suffix to the columns to clear the error.
This now runs correctly as below.

The .values suffix has already been implemented in some other classes (e.g. BOCPDetector) , which we update to .to_numpy() for consistency.

Differential Revision: D30765628

