### PR TITLE
Fix variable name in BackTester examples

### DIFF
--- a/kats/utils/backtesters.py
+++ b/kats/utils/backtesters.py
@@ -545,7 +545,7 @@ class BackTesterExpandingWindow(BackTesterParent):
       >>> backtester = BackTesterExpandingWindow(
             error_methods=all_errors,
             data=ts,
-            params=paramsparams,
+            params=params,
             start_train_percentage=50,
             end_train_percentage=75,
             test_percentage=25,
@@ -713,7 +713,7 @@ class BackTesterRollingWindow(BackTesterParent):
       >>> backtester = BackTesterExpandingWindow(
             error_methods=all_errors,
             data=ts,
-            params=paramsparams,
+            params=params,
             train_percentage=50,
             test_percentage=25,
             expanding_steps=3,
@@ -842,7 +842,7 @@ class BackTesterFixedWindow(BackTesterParent):
       >>> backtester = BackTesterFixedWindow(
             error_methods=all_errors,
             data=ts,
-            params=paramsparams,
+            params=params,
             train_percentage=50,
             test_percentage=25,
             window_percentage=25,
@@ -968,7 +968,7 @@ class CrossValidation:
       >>> cv = CrossValidation(
             error_methods=all_errors,
             data=ts,
-            params=paramsparams,
+            params=params,
             train_percentage=50,
             test_percentage=25,
             num_folds=3,

--- a/kats/utils/backtesters.py
+++ b/kats/utils/backtesters.py
@@ -975,7 +975,7 @@ class CrossValidation:
             model_class=ARIMAModel,
             rolling_window=True
           )
-      >>> backtester.run_backtest()
+      >>> cv.run_cv()
       >>> mape = cv.get_error_value("mape") # Retrieve MAPE error
     """
 


### PR DESCRIPTION
Fix variable name in BackTester examples:
`params` was doubled

Additionally, the second commit fixes #149