### PR TITLE
Extend BackTester docu explaining with terms used in literature

### DIFF
--- a/kats/utils/backtesters.py
+++ b/kats/utils/backtesters.py
@@ -507,6 +507,10 @@ class BackTesterExpandingWindow(BackTesterParent):
     Iterations continue until the complete data set is used to either train
     or test in the final interation.
 
+    This procedure is also known in literature as a rolling origin evaluation
+    with a continously increasing in-sample size (train set) and a constant
+    out-sample size (test set).
+
     For more information, check out the Kats tutorial notebooks!
 
     Attributes:
@@ -515,6 +519,8 @@ class BackTesterExpandingWindow(BackTesterParent):
       end_train_percentage: A float for the final percentage of data used for
         training.
       test_percentage: A float for the percentage of data used for testing.
+        (The test set is taken at sliding positions from start_train_percentage
+         up to the end of the dataset - only the last fold is at the very end.)
       expanding_steps: An integer for the number of expanding steps (i.e.
         number of folds).
       error_methods: List of strings indicating which errors to calculate

--- a/kats/utils/backtesters.py
+++ b/kats/utils/backtesters.py
@@ -684,6 +684,10 @@ class BackTesterRollingWindow(BackTesterParent):
     accommodate. Iterations continue until the end of the test set meets the
     end of the full data set.
 
+    This procedure is also known in literature as a rolling origin evaluation
+    with a constant in-sample size (train set) and a constant out-sample size
+    (test set).
+
     For more information, check out the Kats tutorial notebooks!
 
     Attributes:
@@ -937,12 +941,14 @@ class BackTesterFixedWindow(BackTesterParent):
 
 
 class CrossValidation:
-    """Defines class to execute cross validation.
+    """Defines class to execute time series cross validation.
 
     Cross validation is a useful technique to use multiple folds of the
     training and testing data to help optimize the performance of the
     model (e.g. hyperparameter tuning). For more info on cross validation, see
     https://en.wikipedia.org/wiki/Cross-validation_(statistics)
+
+    This procedure is also known in literature as a rolling origin evaluation.
 
     Attributes:
       train_percentage: A float for the percentage of data used for training.


### PR DESCRIPTION
`BackTesterExpandingWindow` and  `BackTesterRollingWindow` are rolling origin evaluations with increasing or constant size training sets.