### PR TITLE
BackTester: rename CrossValidation arg rolling_window to constant_train_size

### DIFF
--- a/kats/tests/utils/test_backtest.py
+++ b/kats/tests/utils/test_backtest.py
@@ -787,7 +787,7 @@ class CrossValidationTest(unittest.TestCase):
             test_percentage=(100 - PERCENTAGE),
             num_folds=CV_NUM_FOLDS,
             model_class=self.model_class,
-            rolling_window=True,
+            constant_train_size=True,
             multi=False,
         )
         temp_cv.run_cv()

--- a/kats/utils/backtesters.py
+++ b/kats/utils/backtesters.py
@@ -947,8 +947,9 @@ class CrossValidation:
       data: :class:`kats.consts.TimeSeriesData` object to perform backtest on.
       params: Parameters to train model with.
       model_class: Defines the model type to use for backtesting.
-      rolling_window: A boolean flag to use the rolling window method instead
-        of the expanding window method (default False).
+      constant_train_size: A boolean flag to keep the train set size constant,
+          sliding it forward with each iteration instead of expanding the
+          train set with each iteration (default False).
       multi: A boolean flag to toggle multiprocessing (default True).
       results: List of tuples `(training_data, testing_data, trained_model,
         forecast_predictions)` storing forecast results.
@@ -988,7 +989,7 @@ class CrossValidation:
         test_percentage: float,
         num_folds: int,
         model_class: Type,
-        rolling_window=False,
+        constant_train_size=False,
         multi=True,
     ):
         logging.info("Initializing and validating parameter values")
@@ -1021,7 +1022,7 @@ class CrossValidation:
         self.errors = {}
         self.raw_errors = []
 
-        if not rolling_window:
+        if not constant_train_size:
             self._backtester = BackTesterExpandingWindow(
                 error_methods,
                 data,


### PR DESCRIPTION
Both CrossValidation menthods are rolling origin methods with a sliding test set window. 
Thus the arg `rolling_window` is misleading, which is why I propose to rename it to to `constant_train_size`.
See also #152 for details on literature terms.
