### PR TITLE
Add minimal installation option using MINIMAL_KATS

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pip install kats
 
 If you need only a small subset of Kats, you can install a minimal version of Kats with
 ```bash
-MINIMAL=1 pip install kats
+MINIMAL_KATS=1 pip install kats
 ```
 which omits many dependencies (everything in `test_requirements.txt`).
 However, this will disable many functionalities and cause `import kats` to log

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,11 @@ with open("README.md", "r") as f:
 with open("requirements.txt", "r") as f:
     install_requires = f.read().splitlines()
 
-# optional dependencies skipped when MINIMAL=1
+# optional dependencies skipped when MINIMAL_KATS=1
 with open("test_requirements.txt", "r") as f:
     extra_requires = f.read().splitlines()
 
-if not os.environ.get("MINIMAL", False):
+if not os.environ.get("MINIMAL_KATS", False):
     install_requires += extra_requires
 
 


### PR DESCRIPTION
As commented on https://github.com/facebookresearch/Kats/issues/101#issuecomment-947126195, having an environment variable that's exclusive for `kats` avoids installation issues on projects that have multiple other dependencies, and install them using commands like `pip install -r requirements.txt`.

In that scenario, setting `MINIMAL_KATS` avoids unintended side effects on any other dependency that understands the `MINIMAL` environment variable.