### PR TITLE
Fix minimal installation on globalmodel import

### DIFF
--- a/kats/models/__init__.py
+++ b/kats/models/__init__.py
@@ -15,7 +15,14 @@ except ImportError:
     import logging
 
     logging.warning("kats.models.lstm requires torch be installed")
-from . import globalmodel  # noqa
+
+try:
+    from . import globalmodel  # noqa
+except ImportError:
+    import logging
+
+    logging.warning("kats.models.globalmodel requires torch be installed")
+
 from . import metalearner  # noqa
 from . import model  # noqa
 from . import nowcasting  # noqa


### PR DESCRIPTION
Since the introduction of `globalmodel` models, the Kats installation using `MINIMAL_KATS=1` fails with the following error:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/src/kats/__init__.py", line 7, in <module>
    from . import detectors  # noqa # usort: skip
  File "/src/kats/detectors/__init__.py", line 20, in <module>
    from .meta_learning import metalearning_detection_model  # noqa # usort: skip
  File "/src/kats/detectors/meta_learning/metalearning_detection_model.py", line 11, in <module>
    from kats.models.metalearner.metalearner_modelselect import MetaLearnModelSelect
  File "/src/kats/models/__init__.py", line 18, in <module>
    from . import globalmodel  # noqa
  File "/src/kats/models/globalmodel/__init__.py", line 5, in <module>
    from . import backtester  # noqa
  File "/src/kats/models/globalmodel/backtester.py", line 16, in <module>
    import torch
ModuleNotFoundError: No module named 'torch'
```

As the `globalmodel/backtester.py` file requires `torch`, it's needed to just warn about the absense of `torch`, and allow the imports to work for minimal installation.

This behavior was tested using the following imports:
```shell
python -c 'from kats.consts import TimeSeriesData'
python -c 'from kats.models.prophet import ProphetModel'
python -c 'from kats.detectors.cusum_detection import CUSUMDetector'
python -c 'from kats.tsfeatures.tsfeatures import TsFeatures'
```