### PR TITLE
Add typing-extensions requirement for Python 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ scikit-learn>+0.24.2
 seaborn>=0.11.1
 setuptools-git>=1.2
 statsmodels==0.12.2
+typing-extensions>=3.7.4 ; python_version < '3.8'


### PR DESCRIPTION
When running the project on Python 3.7, only installing requirements with:
```
pip install -r requirements.txt
```

The project fails with the following error:
```
$ python -c 'from kats.models.prophet import ProphetModel'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/src/kats/__init__.py", line 6, in <module>
    from . import data  # noqa # usort: skip
  File "/src/kats/data/__init__.py", line 6, in <module>
    from . import utils  # noqa
  File "/src/kats/data/utils.py", line 29, in <module>
    from typing_extensions import Literal
ModuleNotFoundError: No module named 'typing_extensions'
```

This is because, for Python 3.7, `typing-extensions` is needed as `Literal` is not included in stdlib's `typing`.