### PR TITLE
Update statsmodels version to 0.13.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ scikit-learn>=0.24.2
 scipy<1.8.0
 seaborn>=0.11.1
 setuptools-git>=1.2
-statsmodels==0.12.2
+statsmodels==0.13.0
 typing-extensions; python_version < '3.8'


### PR DESCRIPTION
## Kats

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/facebookresearch/Kats/blob/main/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

- [x] Fork the repo and create your branch from `main`.
- [x] If you've added code that should be tested, add tests.
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes.
- [x] Make sure your code lints.
- [x] If you haven't already, complete the Contributor License Agreement ("CLA").

Contributor License Agreement ("CLA")
In order to accept your pull request, we need you to submit a CLA. You only need to do this once to work on any of Facebook's open source projects.

Complete your CLA here: https://code.facebook.com/cla

`Ver: Kats v1.02`

## PR Description

Other repositories that extract timeseries features like [tsfresh==0.19.0](https://github.com/blue-yonder/tsfresh) require statsmodels>=0.13, while current version of Kats require statsmodels==0.12.2. Thus, a dependency conflict occurs when installing both packages in the same development environment. I bumped the statsmodels version to 0.13.0.
