### PR TITLE
Remove numpy version upper bound

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ attrs>=21.2.0
 deprecated>=1.2.12
 importlib_metadata; python_version < '3.8'
 matplotlib>=2.0.0
-numpy>=1.21,<1.22
+numpy>=1.21
 pandas>=1.0.4,<=1.3.5
 python-dateutil>=2.8.0
 pystan==2.19.1.1


### PR DESCRIPTION
In https://github.com/facebookresearch/Kats/commit/6fa409d19395057479bb8044f204486ac849784b, `numpy` was constrained to versions older than `1.22`, because of `numba` not supporting newer versions.

However, `numba` added support for newer `numpy` versions in https://github.com/numba/numba/commit/0b7061ed7360933211b6e21cc34c288999270b6b.