### PR TITLE
Force GH Actions tests

### DIFF
--- a/kats/utils/time_series_parameter_tuning.py
+++ b/kats/utils/time_series_parameter_tuning.py
@@ -45,7 +45,7 @@ MAX_NUM_PROCESSES = 50
 
 
 def compute_search_cardinality(params_space: List[Dict[str, Any]]) -> float:
-    """compute cardinality of search space params"""
+    """Compute cardinality of search space params"""
     # check if search space is infinite
     is_infinite = any([param["type"] == "range" for param in params_space])
     if is_infinite:


### PR DESCRIPTION
Summary: Kats was broken by a version mismatch with Ax last week. Now that Ax has published v0.2.9 this should be addressed. Writing this diff to force GH tests to run on Kats

Differential Revision: D41227293

