### PR TITLE
Bump required Ax version to v0.2.9

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 LunarCalendar>=0.0.9
-ax-platform==0.2.4
+ax-platform==0.2.9
 pystan==2.19.1.1
 fbprophet==0.7.1
 gpytorch<1.9.0


### PR DESCRIPTION
Summary: Kats was broken by a version mismatch with Ax last week. Now that Ax has published v0.2.9 this should be addressed. Writing this diff to force GH tests to run on Kats

Differential Revision: D41233743

