### PR TITLE
fetch_data implementation

### DIFF
--- a/kats/utils/time_series_parameter_tuning.py
+++ b/kats/utils/time_series_parameter_tuning.py
@@ -475,7 +475,7 @@ class TimeSeriesParameterTuning(ABC):
         self._trial_data = Data.from_multiple_data(
             [
                 self._trial_data,
-                self._exp.fetch_trials_data(trial_indices=[max(self._exp.trials)]),
+                self._exp.fetch_data(trial_indices=[max(self._exp.trials)]),
             ]
         )
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/Ax/pull/3977

This commit inlcudes an implementation for fetch_data and unittest associated with it.  fetch_data retrieves data for specified trials and metrics using the experiment's fetch_trials_data_results method. It's particularly useful for getting the latest data when using asynchronous runners. The method converts metric names to actual Metric objects and handles the case when trial_indices is None by fetching data for all trials.

Reviewed By: lena-kashtelyan

Differential Revision: D77246901


