### PR TITLE
Move orchestrator to own module

### DIFF
--- a/kats/utils/time_series_parameter_tuning.py
+++ b/kats/utils/time_series_parameter_tuning.py
@@ -47,8 +47,8 @@ from ax.core.search_space import SearchSpace
 from ax.core.trial import BaseTrial
 from ax.generation_strategy.dispatch_utils import choose_generation_strategy_legacy
 from ax.global_stopping.strategies.improvement import ImprovementGlobalStoppingStrategy
+from ax.orchestration.orchestrator import Orchestrator, OrchestratorOptions
 from ax.runners.synthetic import SyntheticRunner
-from ax.service.orchestrator import Orchestrator, OrchestratorOptions
 from ax.service.utils.instantiation import InstantiationBase
 from ax.utils.common.result import Err, Ok
 from kats.consts import SearchMethodEnum


### PR DESCRIPTION
Summary:
This diff: preliminary cleanup that gets the `Orchestrator` out of `ax/service`, which is generally a misnomer dir and will die once `AxClient` is deprecated.
Overall plan: https://docs.google.com/document/d/1OWGOk1bFjjPpGrYxASYNusONQORdtGiThzCrNy30hkM/edit?tab=t.1lbaw27gcn4u
 {F1984357683}

Differential Revision: D89737933
